### PR TITLE
Add `sys_config` settings

### DIFF
--- a/src/eqc_rebar_prv.erl
+++ b/src/eqc_rebar_prv.erl
@@ -30,6 +30,7 @@ init(State) ->
                     {testing_budget, $t, "testing_budget", integer, "Set total testing time in seconds"},
                     {properties, $p, "properties", string, "Names of properties to check"},
                     {eqc_cover, undefined, "eqc_cover", boolean, "Cover compile usign eqc_cover"},
+                    {sys_config, undefined, "sys_config", string, "Path to a sys.config file to use"},
                     %%  {counterexample, $c, "counterexample", boolean, "Show counterexample"},
                     {plain, $x, "plain", boolean, "Renders plain output"},
                     {shell, $s, "shell", boolean, "Enter and Erlang shell"},
@@ -50,7 +51,6 @@ init(State) ->
     ]),
     {ok, rebar_state:add_provider(State, Provider)}.
 
-
 %% Need to:
 %% - find and run QuickCheck
 %% - compile eqc files in ./eqc and apps/X/eqc
@@ -63,12 +63,25 @@ do(State) ->
     Options = set_defaults(State, #{ pulse => false
                                    , auto_instrument => true %% given that pulse is specified
                                    , eqc_cover => false
+                                   , sys_config => undefined
                                    , shell => false
                                    , plain => false
                                    , install => false
                                    , licence => ""
                                    , compile => false %% only compile if true
                                    }),
+    case find_config(State) of
+      undefined -> State;
+      ConfigPath  ->
+        case file:consult(ConfigPath) of
+          {ok, Config} ->
+            rebar_api:info("Loading config from ~p", [ConfigPath]),
+            %% The `rebar3 shell` plugin also kills apps (with a blacklist for e.g. the kernel)
+            %% before getting to this point and doing reread_config.
+            rebar_utils:reread_config(Config, [update_logger]);
+          {error, Reason} -> rebar_api:abort("Failed to load sys_config: ~p~n", [Reason])
+        end
+    end,
     do(State, Options).
 
 do(State, #{install := true})->
@@ -412,3 +425,11 @@ set_defaults(State, Defaults) ->
 setup_name(State) ->
     {Long, Short, Opts} = rebar_dist_utils:find_options(State),
     rebar_dist_utils:either(Long, Short, Opts).
+
+%% Command line overrides sys_config in rebar.config
+find_config(State) ->
+  {Opts, _} = rebar_state:command_parsed_args(State),
+  case proplists:get_value(sys_config, Opts, undefined) of
+    undefined -> rebar_state:get(State, sys_config, undefined);
+    FilePath  -> FilePath
+  end.

--- a/src/eqc_rebar_prv.erl
+++ b/src/eqc_rebar_prv.erl
@@ -70,6 +70,8 @@ do(State) ->
                                    , licence => ""
                                    , compile => false %% only compile if true
                                    }),
+    %% This idea is copied from the `rebar3 shell` plugin which uses it to
+    %% implement the `--config` option.
     case find_config(State) of
       undefined -> State;
       ConfigPath  ->
@@ -77,7 +79,10 @@ do(State) ->
           {ok, Config} ->
             rebar_api:info("Loading config from ~p", [ConfigPath]),
             %% The `rebar3 shell` plugin also kills apps (with a blacklist for e.g. the kernel)
-            %% before getting to this point and doing reread_config.
+            %% before getting to this point and doing reread_config to make sure none of the apps
+            %% supposed to be started by the shell have already been booted with the wrong config.
+            %% It's not clear if we need to do the same thing here - but for the sake of simplicity
+            %% we don't for now.
             rebar_utils:reread_config(Config, [update_logger]);
           {error, Reason} -> rebar_api:abort("Failed to load sys_config: ~p~n", [Reason])
         end


### PR DESCRIPTION
This let's us specify a `sys.config` using basically the same trick that `rebar shell` uses.